### PR TITLE
Update quarkus to build JVM and native docker images

### DIFF
--- a/Dockerfile.quarkus-jvm
+++ b/Dockerfile.quarkus-jvm
@@ -1,0 +1,7 @@
+FROM hotswapagent/hotswap-vm
+COPY ./target/pingperf-runner.jar /work/application.jar
+COPY ./target/lib /work/lib
+ENV JAVA_OPTS "$JAVA_OPTS -Djava.net.preferIPv4Stack=true -Xmx128m"
+ENTRYPOINT java ${JAVA_OPTS} -cp /work/application -jar /work/application.jar
+WORKDIR /opt
+EXPOSE 8080 8080

--- a/Dockerfile.quarkus-native
+++ b/Dockerfile.quarkus-native
@@ -3,4 +3,4 @@ WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Xmx128m", "-Xms25m", "-Xmn100m", "-R:+PrintGC"]

--- a/Dockerfile.quarkus-native
+++ b/Dockerfile.quarkus-native
@@ -3,4 +3,4 @@ WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Xmx128m", "-Xms25m", "-Xmn100m", "-R:+PrintGC"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Xmx128m", "-Xms25m", "-Xmn100m"]

--- a/build-quarkus-jvm.sh
+++ b/build-quarkus-jvm.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mvn package  && docker build -f Dockerfile.quarkus-jvm -t pingperf-quarkus-jvm .

--- a/build-quarkus-native.sh
+++ b/build-quarkus-native.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mvn package -Pnative -Dnative-image.docker-build=true && docker build -f Dockerfile.quarkus-native -t pingperf-quarkus-native .
+

--- a/build-quarkus.sh
+++ b/build-quarkus.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-mvn package -Pnative -Dnative-image.docker-build=true && docker build -f Dockerfile.quarkus -t pingperf-quarkus .
-

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,8 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+					<enableHttpUrlHandler>true</enableHttpUrlHandler>
+					<uberJar>true</uberJar>
                                 </configuration>
                             </execution>
                         </executions>

--- a/run-quarkus-boot-jvm.sh
+++ b/run-quarkus-boot-jvm.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -ti --rm -p 8080:8080 --network host pingperf-quarkus-jvm

--- a/run-quarkus-boot-native.sh
+++ b/run-quarkus-boot-native.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -ti --rm -p 8080:8080 --network host pingperf-quarkus-native

--- a/run-quarkus-boot.sh
+++ b/run-quarkus-boot.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-docker run -ti --rm -p 8080:8080 pingperf-quarkus


### PR DESCRIPTION
Apply same heap tuning to native image as other runtimes in ping perf test